### PR TITLE
search ordering

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,10 +1,16 @@
 {
 	"cSpell.words": [
 		"formatversion",
+		"oldid",
 		"pageid",
+		"pageids",
 		"revid",
+		"revids",
+		"rvcontentformat",
 		"rvcontinue",
+		"rvdir",
 		"rvlimit",
-		"rvprop"
+		"rvprop",
+		"rvslots"
 	]
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,11 +8,7 @@ import {
 	fetchPageId,
 } from './services/WikipediaAPI';
 import { findOneOccurrence } from './utils/RevisionFinder';
-import {
-	defaultSearchResult,
-	SearchResult,
-	OnSearchFn,
-} from './types';
+import { defaultSearchResult, SearchResult, OnSearchFn } from './types';
 
 function App() {
 	const [searchResult, setSearchResult] =

--- a/src/services/WikipediaAPI.ts
+++ b/src/services/WikipediaAPI.ts
@@ -95,12 +95,18 @@ export async function fetchRevisionTexts(
 
 /**
  * Fetches all revisions of a Wikipedia page in batches of 500.
+ *
+ * The default order is descending (= older last = newer first), but can be changed to ascending.
+ *
+ * see https://www.mediawiki.org/wiki/API:Revisions
  */
 export async function fetchAllRevisions(
 	baseUrl: string,
-	pageId: number
+	pageId: number,
+	order: Order = 'desc'
 ): Promise<ReadonlyArray<number>> {
 	const revisions: number[] = [];
+	const dir = order === 'asc' ? 'newer' : 'older';
 	try {
 		let continueParam: string | null = null;
 		do {
@@ -110,6 +116,7 @@ export async function fetchAllRevisions(
 			url.searchParams.append('pageids', pageId.toString());
 			url.searchParams.append('rvprop', 'ids');
 			url.searchParams.append('rvlimit', '500');
+			url.searchParams.append('rvdir', dir);
 			url.searchParams.append('formatversion', '2');
 			url.searchParams.append('format', 'json');
 			url.searchParams.append('origin', '*');

--- a/src/services/WikipediaAPI.ts
+++ b/src/services/WikipediaAPI.ts
@@ -96,17 +96,17 @@ export async function fetchRevisionTexts(
 /**
  * Fetches all revisions of a Wikipedia page in batches of 500.
  *
- * The default order is descending (= older last = newer first), but can be changed to ascending.
+ * The default order is ascending (= newer last = older first), but can be changed to descending.
  *
  * see https://www.mediawiki.org/wiki/API:Revisions
  */
 export async function fetchAllRevisions(
 	baseUrl: string,
 	pageId: number,
-	order: Order = 'desc'
+	order: Order = 'asc'
 ): Promise<ReadonlyArray<number>> {
 	const revisions: number[] = [];
-	const dir = order === 'asc' ? 'newer' : 'older';
+	const dir = order === 'desc' ? 'older' : 'newer';
 	try {
 		let continueParam: string | null = null;
 		do {

--- a/src/services/WikipediaAPI.ts
+++ b/src/services/WikipediaAPI.ts
@@ -27,6 +27,8 @@ type WikipediaResponse<Slot extends string = 'main'> = {
 	};
 };
 
+type Order = 'asc' | 'desc';
+
 export const getBaseUrl = (lang: WikiLanguage): string =>
 	`https://${lang}.wikipedia.org`;
 


### PR DESCRIPTION
- **add Order type for sorting options in WikipediaAPI**
- **add words in dict**
- **add order parameter to fetchAllRevisions for switching revision sorting**
- **change fetchAllRevisions to use ascending order by default**
