### PR TITLE
fix app-level state to hold baseUrl instead of language

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ function App() {
 	) => {
 		setSearchResult((prev) => ({
 			...prev,
+			baseUrl,
 			pageTitle,
 			targetText,
 			loading: true,

--- a/src/components/ResultView.tsx
+++ b/src/components/ResultView.tsx
@@ -1,5 +1,4 @@
 import { SearchResult } from '../types';
-import { getBaseUrl } from '../services/WikipediaAPI';
 
 type ResultViewProps = {
 	result: SearchResult;
@@ -25,8 +24,7 @@ export function ResultView({ result }: ResultViewProps) {
 		);
 	}
 
-	const baseUrl = getBaseUrl(result.language);
-	const revisionUrl = getRevisionUrl(baseUrl, result.revisionId);
+	const revisionUrl = getRevisionUrl(result.baseUrl, result.revisionId);
 
 	return (
 		<div className="result-view success">

--- a/src/components/__tests__/ResultView.test.tsx
+++ b/src/components/__tests__/ResultView.test.tsx
@@ -12,7 +12,7 @@ describe('ResultView', () => {
 		revisionId: null,
 		loading: false,
 		error: null,
-		language: 'en',
+		baseUrl: 'https://en.wikipedia.org',
 		...overrides,
 	});
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,7 +16,7 @@ export type OnSearchFn = (
 ) => Promise<void>;
 
 export type SearchResult = {
-	language: WikiLanguage;
+	baseUrl: string;
 	pageTitle: string;
 	targetText: string;
 	loading: boolean;
@@ -25,7 +25,7 @@ export type SearchResult = {
 };
 
 export const defaultSearchResult = {
-	language: 'en',
+	baseUrl: 'https://en.wikipedia.org',
 	pageTitle: '',
 	targetText: '',
 	loading: false,


### PR DESCRIPTION
It gets broken at [`d7da9e2` (#12)](https://github.com/Wintus/Wikipedia-Blame/pull/12/commits/d7da9e2676464973659d19c46d158658f53f79f1)