### PR TITLE
add implementation plan for Render-as-You-Fetch in Wikipedia Blame

### DIFF
--- a/render-as-you-fetch-plan.md
+++ b/render-as-you-fetch-plan.md
@@ -22,7 +22,6 @@ This document outlines the implementation strategy for a Render-as-You-Fetch app
 
 ### 3. Simplified State Structure
 
-- Use `baseUrl` directly instead of language-based derivation
 - Minimize state duplication
 - Keep component-specific state local
 
@@ -77,12 +76,11 @@ This document outlines the implementation strategy for a Render-as-You-Fetch app
 
 ## Implementation Sequence
 
-1. Update types to support `baseUrl`
-2. Modify SearchForm for eager fetching
-3. Refactor App component for promise management
-4. Create WikipediaSearchResult for suspense rendering
-5. Implement Error Boundary
-6. Add loading indicators and transitions
+0. Modify SearchForm for eager fetching
+0. Refactor App component for promise management
+0. Create WikipediaSearchResult for suspense rendering
+0. Implement Error Boundary
+0. Add loading indicators and transitions
 
 ## Conclusion
 

--- a/render-as-you-fetch-plan.md
+++ b/render-as-you-fetch-plan.md
@@ -1,0 +1,89 @@
+# Render-as-You-Fetch Implementation Plan for Wikipedia Blame
+
+## Overview
+
+This document outlines the implementation strategy for a Render-as-You-Fetch approach in the Wikipedia Blame application, focusing on early data fetching, suspense-based rendering, and efficient state management.
+
+## Core Architectural Principles
+
+### 1. Eager Data Fetching
+
+- Start fetching page IDs as soon as the title input stabilizes
+- Use a small debounce (300ms) to prevent API hammering
+- Prefetch data before rendering to improve perceived performance
+
+### 2. Promise-Based State Management
+
+- Use independent promises for each fetch stage:
+	- Page ID fetch
+	- Revisions fetch
+	- Occurrence search
+- Allow components to suspend and resume rendering based on promise resolution
+
+### 3. Simplified State Structure
+
+- Use `baseUrl` directly instead of language-based derivation
+- Minimize state duplication
+- Keep component-specific state local
+
+## Key Components
+
+### SearchForm
+
+- Local state for language and input fields
+- Derive `baseUrl` from selected language
+- Eagerly start page ID fetch with debounce
+- Pass prefetched page ID promise to parent
+
+### App Component
+
+- Manage high-level search state
+- Coordinate promise chaining for search process
+- Use Suspense and Error Boundary for robust rendering
+
+### WikipediaSearchResult
+
+- Handle promise unwrapping
+- Suspend and resume rendering based on data availability
+- Update parent component with search results
+
+## Error Handling
+
+- Use Error Boundary to catch and display errors
+- Provide user-friendly error messages
+- Prevent application from breaking on API failures
+
+## Performance Optimizations
+
+- No-store fetch strategy for fresh data
+- Minimal state updates
+- Early promise chaining
+- Suspense-based loading states
+
+## Future Improvements
+
+- Add support for more Wikipedia languages
+- Implement more advanced caching strategies
+- Add transition animations during search
+- Enhance error recovery mechanisms
+
+## Technical Stack
+
+- React 19
+- TypeScript
+- Fetch API
+- Suspense for Data Fetching
+- Error Boundaries
+
+## Implementation Sequence
+
+1. Update types to support `baseUrl`
+2. Modify SearchForm for eager fetching
+3. Refactor App component for promise management
+4. Create WikipediaSearchResult for suspense rendering
+5. Implement Error Boundary
+6. Add loading indicators and transitions
+
+## Conclusion
+
+This implementation provides a modern, performant approach to data fetching in React, leveraging concurrent features to create a responsive user experience.


### PR DESCRIPTION
see https://react.dev/reference/react/Suspense
ja: https://ja.react.dev/reference/react/Suspense

https://ja.react.dev/reference/react/use

ref. https://scrapbox.io/tosuke/Render-as-You-Fetch

ref. https://www.epicreact.dev/render-as-you-fetch

> [!Note]
> We need debounce not defer
> https://ja.react.dev/reference/react/useDeferredValue#how-is-deferring-a-value-different-from-debouncing-and-throttling

