### PR TITLE
migrate to uncontrolled with React 19

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import { ResultView } from './components/ResultView';
 import { searchAction, defaultSearchResult } from './actions/searchActions';
 
 function App() {
-	const [searchResult, formAction, isPending] = useActionState(
+	const [searchState, formAction, isPending] = useActionState(
 		searchAction,
 		defaultSearchResult
 	);
@@ -18,8 +18,8 @@ function App() {
 			</header>
 			<main>
 				<SearchForm formAction={formAction} isPending={isPending} />
-				{searchResult.searchCount > 0 && (
-					<ResultView result={searchResult} isPending={isPending} />
+				{searchState.searchCount > 0 && (
+					<ResultView result={searchState} isPending={isPending} />
 				)}
 			</main>
 		</div>

--- a/src/components/SearchForm.tsx
+++ b/src/components/SearchForm.tsx
@@ -1,5 +1,3 @@
-import { useState } from 'react';
-import { type WikiSite, WIKI_SITES } from '../wiki';
 import { WikiSelector } from './WikiSelector';
 
 type SearchFormProps = {
@@ -8,13 +6,9 @@ type SearchFormProps = {
 };
 
 export function SearchForm({ formAction, isPending }: SearchFormProps) {
-	const [pageTitle, setPageTitle] = useState('');
-	const [targetText, setTargetText] = useState('');
-	const [selectedWiki, setSelectedWiki] = useState<WikiSite>(WIKI_SITES.ENWP);
-
 	return (
 		<form action={formAction} className="search-form" name="searchForm">
-			<WikiSelector selectedWiki={selectedWiki} onChange={setSelectedWiki} />
+			<WikiSelector />
 
 			<div className="form-group">
 				<label htmlFor="page-title">Wiki Article Title:</label>
@@ -22,8 +16,6 @@ export function SearchForm({ formAction, isPending }: SearchFormProps) {
 					type="text"
 					id="page-title"
 					name="pageTitle"
-					value={pageTitle}
-					onChange={(e) => setPageTitle(e.target.value)}
 					placeholder="e.g. Albert Einstein"
 					required
 				/>
@@ -34,8 +26,6 @@ export function SearchForm({ formAction, isPending }: SearchFormProps) {
 				<textarea
 					id="target-text"
 					name="targetText"
-					value={targetText}
-					onChange={(e) => setTargetText(e.target.value)}
 					placeholder="Enter text to search for in the article's history"
 					required
 				/>

--- a/src/components/WikiSelector.tsx
+++ b/src/components/WikiSelector.tsx
@@ -1,14 +1,10 @@
 import { WIKI_SITES } from '../wiki';
 
-type WikiSelectorProps = {
-	selectedWiki?: string;
-};
-
-export function WikiSelector({ selectedWiki = 'enwp' }: WikiSelectorProps) {
+export function WikiSelector() {
 	return (
 		<div className="wiki-selector">
 			<label htmlFor="wiki-select">Wiki Site:</label>
-			<select id="wiki-select" name="wikiId" defaultValue={selectedWiki}>
+			<select id="wiki-select" name="wikiId" defaultValue="enwp">
 				{Object.values(WIKI_SITES).map((wiki) => (
 					<option key={wiki.id} value={wiki.id}>
 						{wiki.name} ({wiki.url.hostname})

--- a/src/components/WikiSelector.tsx
+++ b/src/components/WikiSelector.tsx
@@ -1,30 +1,14 @@
-import { type ChangeEvent } from 'react';
-import { type WikiSite, WIKI_SITES } from '../wiki';
+import { WIKI_SITES } from '../wiki';
 
 type WikiSelectorProps = {
-	selectedWiki: WikiSite;
-	onChange: (wiki: WikiSite) => void;
+	selectedWiki?: string;
 };
 
-export function WikiSelector({ selectedWiki, onChange }: WikiSelectorProps) {
-	const handleChange = (e: ChangeEvent<HTMLSelectElement>) => {
-		const wikiId = e.target.value;
-		const wiki = WIKI_SITES[wikiId.toUpperCase() as keyof typeof WIKI_SITES];
-		if (wiki) {
-			onChange(wiki);
-		}
-	};
-
+export function WikiSelector({ selectedWiki = 'enwp' }: WikiSelectorProps) {
 	return (
 		<div className="wiki-selector">
 			<label htmlFor="wiki-select">Wiki Site:</label>
-			<select
-				id="wiki-select"
-				name="wikiId"
-				key={selectedWiki.id}
-				defaultValue={selectedWiki.id}
-				onChange={handleChange}
-			>
+			<select id="wiki-select" name="wikiId" defaultValue={selectedWiki}>
 				{Object.values(WIKI_SITES).map((wiki) => (
 					<option key={wiki.id} value={wiki.id}>
 						{wiki.name} ({wiki.url.hostname})

--- a/src/components/__tests__/SearchForm.test.tsx
+++ b/src/components/__tests__/SearchForm.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { SearchForm } from '../SearchForm';
 
 describe('SearchForm', () => {
@@ -22,15 +23,16 @@ describe('SearchForm', () => {
 		).toBeInTheDocument();
 	});
 
-	it('submits form with correct FormData', () => {
+	it('submits form with correct FormData', async () => {
+		const user = userEvent.setup();
 		render(<SearchForm {...defaultProps} />);
 		const titleInput = screen.getByLabelText(/Wiki Article Title:/i);
 		const textArea = screen.getByLabelText(/Text to Find:/i);
 		const button = screen.getByRole('button', { name: /Find An Occurrence/i });
 
-		fireEvent.change(titleInput, { target: { value: 'Albert Einstein' } });
-		fireEvent.change(textArea, { target: { value: 'relativity' } });
-		fireEvent.click(button);
+		await user.type(titleInput, 'Albert Einstein');
+		await user.type(textArea, 'relativity');
+		await user.click(button);
 
 		expect(mockFormAction).toHaveBeenCalledTimes(1);
 
@@ -44,10 +46,11 @@ describe('SearchForm', () => {
 		expect(wikiId).toEqual('enwp');
 	});
 
-	it('does not submit when inputs are empty', () => {
+	it('submits form with empty inputs', async () => {
+		const user = userEvent.setup();
 		render(<SearchForm {...defaultProps} />);
 		const button = screen.getByRole('button', { name: /Find An Occurrence/i });
-		fireEvent.click(button);
+		await user.click(button);
 		expect(mockFormAction).not.toHaveBeenCalled();
 	});
 
@@ -64,15 +67,18 @@ describe('SearchForm', () => {
 		expect(screen.getByLabelText(/Wiki Site:/i)).toBeInTheDocument();
 	});
 
-	it('the selected option remains selected after form submission', () => {
+	it('the selected option remains selected after form submission', async () => {
+		const user = userEvent.setup();
 		render(<SearchForm {...defaultProps} />);
 		const wikiSelector =
 			screen.getByLabelText<HTMLSelectElement>(/Wiki Site:/i);
 
-		fireEvent.change(wikiSelector, { target: { value: 'jawp' } });
+		await user.selectOptions(wikiSelector, 'jawp');
 		expect(wikiSelector.value).toBe('jawp');
 
-		fireEvent.submit(screen.getByRole('form'));
+		await user.click(
+			screen.getByRole('button', { name: /Find An Occurrence/i })
+		);
 		expect(wikiSelector.value).toBe('jawp');
 	});
 });

--- a/src/components/__tests__/WikiSelector.test.tsx
+++ b/src/components/__tests__/WikiSelector.test.tsx
@@ -23,13 +23,6 @@ describe('WikiSelector', () => {
 		expect(selectElement.value).toBe('enwp');
 	});
 
-	it('displays correct alternative wiki when provided', () => {
-		render(<WikiSelector selectedWiki="jawp" />);
-		const selectElement =
-			screen.getByLabelText<HTMLSelectElement>('Wiki Site:');
-		expect(selectElement.value).toBe('jawp');
-	});
-
 	it('renders options with correct text and values', () => {
 		render(<WikiSelector />);
 		const options = screen.getAllByRole('option') as HTMLOptionElement[];

--- a/src/components/__tests__/WikiSelector.test.tsx
+++ b/src/components/__tests__/WikiSelector.test.tsx
@@ -1,53 +1,37 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
 import { WikiSelector } from '../WikiSelector';
-import { WIKI_SITES, type WikiSite } from '../../wiki';
+import { WIKI_SITES } from '../../wiki';
 
 describe('WikiSelector', () => {
-	const renderComponent = (
-		selectedWiki: WikiSite = WIKI_SITES.ENWP,
-		onChange = vi.fn()
-	) => render(<WikiSelector selectedWiki={selectedWiki} onChange={onChange} />);
-
 	it('renders the component with correct label', () => {
-		renderComponent();
+		render(<WikiSelector />);
 		const label = screen.getByText('Wiki Site:');
 		expect(label).toBeInTheDocument();
 	});
 
 	it('renders select element with correct id', () => {
-		renderComponent();
+		render(<WikiSelector />);
 		const selectElement = screen.getByLabelText('Wiki Site:');
 		expect(selectElement).toHaveAttribute('id', 'wiki-select');
 	});
 
 	it('displays correct default wiki', () => {
-		renderComponent(WIKI_SITES.ENWP);
+		render(<WikiSelector />);
 		const selectElement =
 			screen.getByLabelText<HTMLSelectElement>('Wiki Site:');
-		expect(selectElement.value).toBe(WIKI_SITES.ENWP.id);
+		expect(selectElement.value).toBe('enwp');
 	});
 
 	it('displays correct alternative wiki when provided', () => {
-		renderComponent(WIKI_SITES.JAWP);
+		render(<WikiSelector selectedWiki="jawp" />);
 		const selectElement =
 			screen.getByLabelText<HTMLSelectElement>('Wiki Site:');
-		expect(selectElement.value).toBe(WIKI_SITES.JAWP.id);
-	});
-
-	it('calls onChange with correct wiki when changed', () => {
-		const mockOnChange = vi.fn();
-		renderComponent(WIKI_SITES.ENWP, mockOnChange);
-		const selectElement =
-			screen.getByLabelText<HTMLSelectElement>('Wiki Site:');
-		fireEvent.change(selectElement, {
-			target: { value: WIKI_SITES.JAWP.id },
-		});
-		expect(mockOnChange).toHaveBeenCalledWith(WIKI_SITES.JAWP);
+		expect(selectElement.value).toBe('jawp');
 	});
 
 	it('renders options with correct text and values', () => {
-		renderComponent();
+		render(<WikiSelector />);
 		const options = screen.getAllByRole('option') as HTMLOptionElement[];
 		expect(options.length).toBe(Object.keys(WIKI_SITES).length);
 		for (const option of options) {


### PR DESCRIPTION
simplify

# checks:

- [ ] regression


# references

* ref. https://ja.react.dev/reference/react-dom/components/form#props
* ref. https://zenn.dev/uhyo/books/react-19-new/viewer/form-action
* ref. https://react.dev/blog/2024/12/05/react-19

