### PR TITLE
separate vite vitest

### DIFF
--- a/src/components/PageIdFetcher.tsx
+++ b/src/components/PageIdFetcher.tsx
@@ -25,7 +25,7 @@ export function PageIdFetcher({ promise }: Props) {
 
 // MARK: in-source tests
 if (import.meta.vitest) {
-	const { describe, it, expect } = await import('vitest');
+	const { describe, it, expect } = import.meta.vitest;
 	const { render, act, screen, waitFor } = await import(
 		'@testing-library/react'
 	);

--- a/src/components/ResultView.tsx
+++ b/src/components/ResultView.tsx
@@ -58,7 +58,7 @@ export function ResultView({ result, isPending }: ResultViewProps) {
 
 // MARK: in-source tests
 if (import.meta.vitest) {
-	const { describe, it, expect } = await import('vitest');
+	const { describe, it, expect } = import.meta.vitest;
 	const { render, screen } = await import('@testing-library/react');
 
 	describe('ResultView', () => {

--- a/src/components/WikiSelector.tsx
+++ b/src/components/WikiSelector.tsx
@@ -36,7 +36,7 @@ export function WikiSelector({ selectedWiki, onChange }: WikiSelectorProps) {
 
 // MARK: in-source tests
 if (import.meta.vitest) {
-	const { describe, it, expect, vi } = await import('vitest');
+	const { describe, it, expect, vi } = import.meta.vitest;
 	const { render, screen, fireEvent } = await import('@testing-library/react');
 
 	const ENWP_URL = new URL('https://en.wikipedia.org');

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,17 +1,8 @@
-import { defineConfig } from 'vitest/config';
+import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react-swc';
 
 // https://vite.dev/config/
 export default defineConfig({
 	base: '/Wikipedia-Blame/',
 	plugins: [react()],
-	test: {
-		globals: true,
-		environment: 'happy-dom',
-		includeSource: ['src/**/*.{js,ts,jsx,tsx}'],
-		setupFiles: './src/setupTests.ts',
-	},
-  define: {
-    'import.meta.vitest': 'undefined',
-  },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react-swc';
+
+// https://vite.dev/config/
+export default defineConfig({
+	base: '/Wikipedia-Blame/',
+	plugins: [react()],
+	test: {
+		globals: true,
+		environment: 'happy-dom',
+		includeSource: ['src/**/*.{js,ts,jsx,tsx}'],
+		setupFiles: './src/setupTests.ts',
+	},
+  define: {
+    'import.meta.vitest': 'undefined',
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,17 +1,18 @@
-import { defineConfig } from 'vitest/config';
-import react from '@vitejs/plugin-react-swc';
+import { defineConfig, mergeConfig } from 'vitest/config';
+import viteConfig from './vite.config';
 
-// https://vite.dev/config/
-export default defineConfig({
-	base: '/Wikipedia-Blame/',
-	plugins: [react()],
-	test: {
-		globals: true,
-		environment: 'happy-dom',
-		includeSource: ['src/**/*.{js,ts,jsx,tsx}'],
-		setupFiles: './src/setupTests.ts',
-	},
-  define: {
-    'import.meta.vitest': 'undefined',
-  },
-});
+// https://vitest.dev/guide/#configuring-vitest
+export default mergeConfig(
+	viteConfig,
+	defineConfig({
+		test: {
+			globals: true,
+			environment: 'happy-dom',
+			includeSource: ['src/**/*.{js,ts,jsx,tsx}'],
+			setupFiles: './src/setupTests.ts',
+		},
+		define: {
+			'import.meta.vitest': 'undefined',
+		},
+	})
+);


### PR DESCRIPTION
https://vitest.dev/guide/#configuring-vitest

> WARNING
> 
> If you decide to have two separate config files for Vite and Vitest, make sure to define the same Vite options in your Vitest config file since it will override your Vite file, not extend it. You can also use mergeConfig method from vite or vitest/config entries to merge Vite config with Vitest config:
> [...]
> However, we recommend using the same file for both Vite and Vitest, instead of creating two separate files.

