### PR TITLE
remove waitFor

### DIFF
--- a/src/components/PageIdFetcher.tsx
+++ b/src/components/PageIdFetcher.tsx
@@ -26,9 +26,7 @@ export function PageIdFetcher({ promise }: Props) {
 // MARK: in-source tests
 if (import.meta.vitest) {
 	const { describe, it, expect } = import.meta.vitest;
-	const { render, act, screen, waitFor } = await import(
-		'@testing-library/react'
-	);
+	const { render, act, screen } = await import('@testing-library/react');
 
 	describe('PageIdFetcher', () => {
 		it('renders without crashing', async () => {
@@ -37,9 +35,7 @@ if (import.meta.vitest) {
 				render(<PageIdFetcher promise={promise} />)
 			);
 			expect(container).not.toBeEmptyDOMElement();
-			await waitFor(() =>
-				expect(screen.getByTestId('pageId-input')).toHaveValue('')
-			);
+			expect(screen.getByTestId('pageId-input')).toHaveValue('');
 		});
 
 		it('crashes with rejected promise', async () => {
@@ -54,9 +50,7 @@ if (import.meta.vitest) {
 		it('renders correct pageId when promise resolves with an ID', async () => {
 			const promise = Promise.resolve({ id: '123' });
 			await act(async () => render(<PageIdFetcher promise={promise} />));
-			await waitFor(() =>
-				expect(screen.getByTestId('pageId-input')).toHaveValue('123')
-			);
+			expect(screen.getByTestId('pageId-input')).toHaveValue('123');
 			expect(
 				screen.queryByText('Error fetching page ID. Please try again.')
 			).not.toBeInTheDocument();
@@ -65,9 +59,7 @@ if (import.meta.vitest) {
 		it('renders empty pageId when promise resolves with null ID', async () => {
 			const promise = Promise.resolve({ id: null });
 			await act(async () => render(<PageIdFetcher promise={promise} />));
-			await waitFor(() =>
-				expect(screen.getByTestId('pageId-input')).toHaveValue('')
-			);
+			expect(screen.getByTestId('pageId-input')).toHaveValue('');
 			expect(
 				screen.queryByText('Error fetching page ID. Please try again.')
 			).not.toBeInTheDocument();
@@ -76,9 +68,7 @@ if (import.meta.vitest) {
 		it('renders error message when promise resolves with an error string', async () => {
 			const promise = Promise.resolve({ error: 'Specific error message' });
 			await act(async () => render(<PageIdFetcher promise={promise} />));
-			await waitFor(() =>
-				expect(screen.getByText('Specific error message')).toBeInTheDocument()
-			);
+			expect(screen.getByText('Specific error message')).toBeInTheDocument();
 			expect(screen.getByTestId('pageId-input')).toHaveValue('');
 		});
 	});

--- a/src/components/PageTitleInput.tsx
+++ b/src/components/PageTitleInput.tsx
@@ -59,7 +59,7 @@ export function PageTitleInput({
 if (import.meta.vitest) {
 	const { describe, it, expect, vi, beforeEach, beforeAll, afterAll } =
 		import.meta.vitest;
-	const { render, screen, act, fireEvent, waitFor, waitForElementToBeRemoved } =
+	const { render, screen, act, fireEvent, waitForElementToBeRemoved } =
 		await import('@testing-library/react');
 	const MediaWikiAPIs = await import('../services/MediaWikiAPIs');
 
@@ -99,9 +99,7 @@ if (import.meta.vitest) {
 			await act(async () =>
 				render(<PageTitleInput initialPageTitle="" wikiUrl={stubWikiUrl} />)
 			);
-			await waitFor(() => {
-				expect(screen.getByTestId('pageId-input')).toBeInTheDocument();
-			});
+			expect(screen.getByTestId('pageId-input')).toBeInTheDocument();
 		});
 
 		it('updates the input value on change', async () => {
@@ -116,9 +114,7 @@ if (import.meta.vitest) {
 			) as HTMLInputElement;
 
 			// Wait for the debounce and API call
-			await waitFor(() => expect(mockFetchPageId).toHaveBeenCalledTimes(1), {
-				timeout: 300,
-			});
+			expect(mockFetchPageId).toHaveBeenCalledTimes(1);
 
 			await act(async () =>
 				fireEvent.change(inputElement, { target: { value: 'New Title' } })
@@ -134,9 +130,7 @@ if (import.meta.vitest) {
 			expect(loadingIndicator).toBeInTheDocument();
 
 			// Wait for the debounce and API call
-			await waitFor(() => expect(mockFetchPageId).toHaveBeenCalledTimes(2), {
-				timeout: 300,
-			});
+			expect(mockFetchPageId).toHaveBeenCalledTimes(2);
 			await waitForElementToBeRemoved(() =>
 				screen.getByText('Checking title...')
 			);
@@ -167,9 +161,7 @@ if (import.meta.vitest) {
 			expect(loadingIndicator).toBeInTheDocument();
 
 			// Wait for the debounce and API call
-			await waitFor(() => expect(mockFetchPageId).toHaveBeenCalledTimes(1), {
-				timeout: 300,
-			});
+			expect(mockFetchPageId).toHaveBeenCalledTimes(1);
 			await waitForElementToBeRemoved(() =>
 				screen.getByText('Checking title...')
 			);
@@ -185,12 +177,8 @@ if (import.meta.vitest) {
 				)
 			);
 			// Wait for the API call
-			await waitFor(() => expect(mockFetchPageId).toHaveBeenCalledTimes(1), {
-				timeout: 300,
-			});
-			await waitFor(() =>
-				expect(screen.getByTestId('pageId-input')).toBeInTheDocument()
-			);
+			expect(mockFetchPageId).toHaveBeenCalledTimes(1);
+			expect(screen.getByTestId('pageId-input')).toBeInTheDocument();
 			const hiddenInput = screen.getByTestId(
 				'pageId-input'
 			) as HTMLInputElement;
@@ -209,12 +197,8 @@ if (import.meta.vitest) {
 				)
 			);
 			// Wait for the API call
-			await waitFor(() => expect(mockFetchPageId).toHaveBeenCalledTimes(1), {
-				timeout: 300,
-			});
-			await waitFor(() =>
-				expect(screen.getByTestId('pageId-input')).toBeInTheDocument()
-			);
+			expect(mockFetchPageId).toHaveBeenCalledTimes(1);
+			expect(screen.getByTestId('pageId-input')).toBeInTheDocument();
 
 			const hiddenInput = screen.getByTestId(
 				'pageId-input'

--- a/src/components/SearchForm.tsx
+++ b/src/components/SearchForm.tsx
@@ -163,9 +163,9 @@ if (import.meta.vitest) {
 
 			await act(async () => {
 				fireEvent.change(titleInput, { target: { value: 'Albert Einstein' } });
+				fireEvent.change(textArea, { target: { value: 'relativity' } });
+				fireEvent.click(button);
 			});
-			fireEvent.change(textArea, { target: { value: 'relativity' } });
-			fireEvent.click(button);
 
 			expect(mockFormAction).toHaveBeenCalledTimes(1);
 
@@ -230,10 +230,10 @@ if (import.meta.vitest) {
 
 			await act(async () => {
 				fireEvent.change(titleInput, { target: { value: 'Albert Einstein' } });
+				fireEvent.change(textArea, { target: { value: 'relativity' } });
+				fireEvent.change(endRevIdInput, { target: { value: '67890' } });
+				fireEvent.click(button);
 			});
-			fireEvent.change(textArea, { target: { value: 'relativity' } });
-			fireEvent.change(endRevIdInput, { target: { value: '67890' } });
-			fireEvent.click(button);
 
 			expect(mockFormAction).toHaveBeenCalledTimes(1);
 

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -44,9 +44,7 @@ if (import.meta.vitest) {
 
 			expect(result.current).toBe('initial');
 
-			act(() => {
-				rerender({ value: 'updated', delay: 100 });
-			});
+			rerender({ value: 'updated', delay: 100 });
 
 			expect(result.current).toBe('initial'); // Still initial value
 
@@ -67,9 +65,7 @@ if (import.meta.vitest) {
 
 			expect(result.current).toBe('initial');
 
-			act(() => {
-				rerender({ value: 'updated' });
-			});
+			rerender({ value: 'updated' });
 
 			expect(result.current).toBe('initial'); // Still initial value
 
@@ -91,17 +87,13 @@ if (import.meta.vitest) {
 
 			expect(result.current).toBe('initial');
 
-			act(() => {
-				rerender({ value: 'updated', delay: 0 });
-			});
+			rerender({ value: 'updated', delay: 0 });
 
 			expect(result.current).toBe('initial');
 
-			act(() => {
-				rerender({ value: 'updated', delay: 0 });
-			});
+			rerender({ value: 'updated', delay: 0 });
 
-			await waitFor(() => expect(result.current).toBe('updated')); // Updated immediately
+			waitFor(() => expect(result.current).toBe('updated')); // Updated immediately
 		});
 	});
 }


### PR DESCRIPTION
While the `render` is said to contain `act`, we still need to wrap it somehow. Instead, we can remove `waitFor` with awaited `act`.

Note: It's may be due to React 19 with `Suspense`.

ref.

* https://testing-library.com/docs/react-testing-library/api/#render
* https://testing-library.com/docs/react-testing-library/api/#act
* https://testing-library.com/docs/dom-testing-library/api-async/#waitfor
