### PR TITLE
Fix lint error: Remove async keyword from useMemo callback

### DIFF
--- a/src/components/PageTitleInput.tsx
+++ b/src/components/PageTitleInput.tsx
@@ -15,19 +15,18 @@ export function PageTitleInput({
 	const [pageTitle, setPageTitle] = useState(initialPageTitle);
 	const debouncedPageTitle = useDebounce(pageTitle.trim(), 300);
 
-	const pageIdPromise = useMemo(async () => {
+	const pageIdPromise = useMemo(() => {
 		// guard
 		if (!debouncedPageTitle) {
-			return {};
+			return Promise.resolve({});
 		}
 		// fetch page ID
-		try {
-			const id = await fetchPageId(wikiUrl, debouncedPageTitle);
-			return { id: id.toString() };
-		} catch (error) {
-			console.error('Error fetching page ID:', error);
-			return { error: 'Error fetching page ID. Please try again.' };
-		}
+		return fetchPageId(wikiUrl, debouncedPageTitle)
+			.then((id) => ({ id: id.toString() }))
+			.catch((error) => {
+				console.error('Error fetching page ID:', error);
+				return { error: 'Error fetching page ID. Please try again.' };
+			});
 	}, [wikiUrl, debouncedPageTitle]);
 
 	return (

--- a/src/components/PageTitleInput.tsx
+++ b/src/components/PageTitleInput.tsx
@@ -15,6 +15,8 @@ export function PageTitleInput({
 	const [pageTitle, setPageTitle] = useState(initialPageTitle);
 	const debouncedPageTitle = useDebounce(pageTitle.trim(), 300);
 
+	// Note: useMemo callback cannot be async (linter rule), but returning a Promise is fine.
+	// Semantically equivalent to async/await, but React wants explicit Promise return.
 	const pageIdPromise = useMemo(() => {
 		// guard
 		if (!debouncedPageTitle) {


### PR DESCRIPTION
## Summary
- Fixed ESLint error in [PageTitleInput.tsx](src/components/PageTitleInput.tsx) where `useMemo` callback was using `async` keyword
- Rewrote the async function to return a Promise using `.then()/.catch()` pattern instead
- Added documentation comment explaining the linter rule and rationale

## Details
The React compiler doesn't allow async functions as useMemo callbacks. While semantically equivalent, React prefers explicit Promise returns to make it clear the callback itself runs synchronously even though it returns async work.

see https://github.com/facebook/react/blob/v19.2.0/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateUseMemo.ts#L90-L105

The ESLint has started alerting this since v7

* #122 
* https://github.com/facebook/react/blob/main/packages/eslint-plugin-react-hooks/CHANGELOG.md#700

## Changes
- Converted `useMemo(async () => {...})` to `useMemo(() => Promise.resolve(...).then())`
- Added clarifying comment about the linter rule requirement

## Test plan
- [x] `npm run lint` passes without errors
- [x] Existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)