### PR TITLE
ci: skip Claude Code review for Dependabot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,8 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Skip Dependabot PRs (cannot access repository secrets)
+    if: github.actor != 'dependabot[bot]'
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- Skip Claude Code review workflow for Dependabot PRs
- Dependabot cannot access repository secrets, causing workflow failures

## Root cause
Dependabot runs in a separate security context and cannot access repository secrets. This caused the workflow to fail with:
> Either ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN is required

## Test plan
- [ ] ~~Verify new non-Dependabot PRs trigger the workflow~~
- [ ] ~~Verify Dependabot PRs skip the workflow (check Actions tab shows "skipped")~~

---

Both of them are not possible. See https://github.com/anthropics/claude-code-action/issues/722

Co-Authored-By: Claude

