### PR TITLE
Remove explicit useMemo (React Compiler handles it)

### DIFF
--- a/src/components/PageTitleInput.tsx
+++ b/src/components/PageTitleInput.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useMemo, useState } from 'react';
+import { Suspense, useState } from 'react';
 import useDebounce from '../hooks/useDebounce';
 import { fetchPageId } from '../services/MediaWikiAPIs';
 import { PageIdFetcher } from './PageIdFetcher';
@@ -15,9 +15,8 @@ export function PageTitleInput({
 	const [pageTitle, setPageTitle] = useState(initialPageTitle);
 	const debouncedPageTitle = useDebounce(pageTitle.trim(), 300);
 
-	// Note: useMemo callback cannot be async (linter rule), but returning a Promise is fine.
-	// Semantically equivalent to async/await, but React wants explicit Promise return.
-	const pageIdPromise = useMemo(() => {
+	// React Compiler auto-memoizes based on reactive dependencies (wikiUrl, debouncedPageTitle)
+	const pageIdPromise = (() => {
 		// guard
 		if (!debouncedPageTitle) {
 			return Promise.resolve({});
@@ -29,7 +28,7 @@ export function PageTitleInput({
 				console.error('Error fetching page ID:', error);
 				return { error: 'Error fetching page ID. Please try again.' };
 			});
-	}, [wikiUrl, debouncedPageTitle]);
+	})();
 
 	return (
 		<div className="form-group">

--- a/src/components/PageTitleInput.tsx
+++ b/src/components/PageTitleInput.tsx
@@ -16,18 +16,19 @@ export function PageTitleInput({
 	const debouncedPageTitle = useDebounce(pageTitle.trim(), 300);
 
 	// React Compiler auto-memoizes based on reactive dependencies (wikiUrl, debouncedPageTitle)
-	const pageIdPromise = (() => {
+	const pageIdPromise = (async () => {
 		// guard
 		if (!debouncedPageTitle) {
-			return Promise.resolve({});
+			return {};
 		}
 		// fetch page ID
-		return fetchPageId(wikiUrl, debouncedPageTitle)
-			.then((id) => ({ id: id.toString() }))
-			.catch((error) => {
-				console.error('Error fetching page ID:', error);
-				return { error: 'Error fetching page ID. Please try again.' };
-			});
+		try {
+			const id = await fetchPageId(wikiUrl, debouncedPageTitle);
+			return { id: id.toString() };
+		} catch (error) {
+			console.error('Error fetching page ID:', error);
+			return { error: 'Error fetching page ID. Please try again.' };
+		}
 	})();
 
 	return (


### PR DESCRIPTION
## Summary

- Remove explicit `useMemo` from `PageTitleInput` component
- React Compiler auto-memoizes based on reactive dependencies

## Verification

- [x] Confirmed "Memo ✨" badge appears in React DevTools
- [x] Linter passes
- [x] All tests pass
- [x] Build succeeds

## References

- Depends on #149 (React Compiler setup)

Co-Authored-By: Claude