### PR TITLE
refactor: replace deprecated tseslint.config with defineConfig

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,10 +1,11 @@
+import { defineConfig } from 'eslint/config';
 import js from '@eslint/js';
 import globals from 'globals';
 import reactHooks from 'eslint-plugin-react-hooks';
 import reactRefresh from 'eslint-plugin-react-refresh';
 import tseslint from 'typescript-eslint';
 
-export default tseslint.config(
+export default defineConfig(
 	{ ignores: ['dist'] },
 	{
 		extends: [js.configs.recommended, ...tseslint.configs.recommended],


### PR DESCRIPTION
## Summary
- Replace deprecated `tseslint.config()` with ESLint's native `defineConfig()` from `eslint/config`

## Background
The `tseslint.config()` function was deprecated in favor of ESLint's `defineConfig()` (introduced in ESLint v9.22.0).

Reference: https://typescript-eslint.io/packages/typescript-eslint/#config-deprecated

## Test plan
- [x] `npm run lint` passes
- [x] `npm run build` passes

Co-Authored-By: Claude