### PR TITLE
Fix PageTitleInput reset on wiki site change

### DIFF
--- a/src/components/SearchForm.tsx
+++ b/src/components/SearchForm.tsx
@@ -21,6 +21,7 @@ export function SearchForm({
 			<WikiSelector selectedWiki={wikiUrl} onChange={setWikiUrl} />
 
 			<PageTitleInput
+				key={wikiUrl.href}
 				initialPageTitle={searchState.pageTitle}
 				wikiUrl={wikiUrl}
 			/>
@@ -326,6 +327,36 @@ if (import.meta.vitest) {
 			user.click(button);
 
 			expect(wikiSelector.value).toBe('https://ja.wikipedia.org/');
+		});
+
+		it('resets page title input when wiki site changes', async () => {
+			const { fireEvent } = await import('@testing-library/react');
+			const user = userEvent.setup();
+			await act(async () => renderWithQuery(<SearchForm {...defaultProps} />));
+			const titleInput = screen.getByLabelText(
+				/Wiki Article Title:/i
+			) as HTMLInputElement;
+
+			// User types a different title
+			await user.clear(titleInput);
+			await user.type(titleInput, 'Albert Einstein');
+			expect(titleInput.value).toBe('Albert Einstein');
+
+			// Switch wiki site
+			const wikiSelector =
+				screen.getByLabelText<HTMLSelectElement>(/Wiki Site:/i);
+			await act(async () => {
+				// use fireEvent due to warning of act unsupported
+				fireEvent.change(wikiSelector, {
+					target: { value: 'https://ja.wikipedia.org/' },
+				});
+			});
+
+			// PageTitleInput remounts → title resets to initialPageTitle
+			const resetTitleInput = screen.getByLabelText(
+				/Wiki Article Title:/i
+			) as HTMLInputElement;
+			expect(resetTitleInput.value).toBe('Initial Title');
 		});
 
 		it('renders initial values from searchState', async () => {


### PR DESCRIPTION
## Summary

Fixes PageTitleInput state not resetting when users switch wiki sites (e.g., en.wikipedia.org → ja.wikipedia.org).

## Problem

When the wiki selector changed, PageTitleInput retained stale state:
1. **`pageTitle` (useState)** — didn't re-initialize (React reused component instance)
2. **`debouncedTitle` (useDebouncedValue)** — carried over from old wiki
3. **ErrorBoundary** — stuck errors persisted if title text hadn't changed (resetKeys was `[debouncedTitle]` only)

TanStack Query already handled re-fetching correctly via `queryKey: ['pageId', wikiUrl.href, pageTitle]` — no changes needed there.

## Solution

Added `key={wikiUrl.href}` to `<PageTitleInput>` in SearchForm.tsx.

This is React's documented pattern for "resetting all state when a prop changes." When the key changes, React unmounts the old instance and mounts a fresh one, resetting all internal state to initial values.

## Why This Approach

**Option A (chosen): `key={wikiUrl.href}`**
- Fixes all three issues with zero code changes inside PageTitleInput
- React-recommended pattern
- Clear, declarative intent

**Option B (rejected): Add `wikiUrl.href` to ErrorBoundary resetKeys**
- Would fix error boundary (issue 3) only
- Still need useEffect or similar for issues 1 & 2
- React docs discourage this pattern in favor of `key`

## Testing

- Added regression test: "resets page title input when wiki site changes"
- Test **passes** with `key={wikiUrl.href}` ✓
- Test **fails** without the key (regression guard confirmed) ✗
- All 71 tests pass

## Test Plan

- [x] Automated tests pass
- [x] Manual verification: Type a title, switch wiki site, confirm input resets
- [x] Verify error states clear when switching wikis

Co-Authored-By: Claude